### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest, macos-latest, windows-latest]
+        runner: [ubuntu-latest, macos-latest] # , windows-latest
         perl: [ '5.32' ]
 
     runs-on: ${{matrix.runner}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: Perl
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+        perl: [ '5.32' ]
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up perl
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+          perl-version: ${{ matrix.perl }}
+          distribution: ${{ ( startsWith( matrix.runner, 'windows-' ) && 'strawberry' ) || 'default' }}
+
+    - name: Show Perl Version
+      run: |
+        perl -v
+
+    - name: Install Modules
+      run: |
+        cpanm -v
+        cpanm --installdeps .
+
+    - name: Run tests
+      env:
+        RELEASE_TESTING: 1
+      run: |
+        perl Makefile.PL
+        make
+        make test
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,17 @@ jobs:
       run: |
         cpanm -v
         cpanm --installdeps .
+        cpanm Test::CheckManifest
 
     - name: Run tests
-      env:
-        RELEASE_TESTING: 1
+      # RELEASE_TESTING is not enabled as some of the tests take way too long (more than 30 minutes)
       run: |
         perl Makefile.PL
         make
         make test
 
+    - name: Run release tests
+      env:
+        RELEASE_TESTING: 1
+      run: |
+        prove t/manifest.t


### PR DESCRIPTION
* First I tried to enable RELEASE_TESTING for all the tests, but the execution time was longer than 30 minutes so instead of that I added a separate step for the RELEASE_TESTING.
* On Windows the tests fail.
